### PR TITLE
update library calls for lts-14.1; remove redundant imports

### DIFF
--- a/Frames-beam.cabal
+++ b/Frames-beam.cabal
@@ -37,10 +37,10 @@ library
         , beam-migrate >=0.3.2.1
         , text >=1.2.3.0
         , postgresql-simple >=0.5.3.0
-        , Frames >=0.5 && <0.6
+        , Frames >=0.5 && <=0.6.1
         , template-haskell >=2.12.0.0
         , generics-sop >=0.3.2.0
-        , vinyl >=0.10 && <0.11
+        , vinyl >=0.10 && <=0.11.0
         , process >=1.6.1.0
         , conduit >=1.3.0.2 
         , monad-control >=1.0.2.3 
@@ -67,8 +67,8 @@ test-suite spec
         , conduit >=1.3.0.2 
         , generics-sop >=0.3.2.0 
         , text >=1.2.3.0
-        , vinyl >=0.10 && <0.11
-        , Frames >=0.5 && <0.6
+        , vinyl >=0.10 && <=0.11.0
+        , Frames >=0.5 && <=0.6.1
         , beam-core >=0.7.2.1 
         , beam-postgres >=0.3.2.0
         , beam-migrate >=0.3.2.1

--- a/src/Frames/SQL/Beam/Postgres/BeamSchemaGen.hs
+++ b/src/Frames/SQL/Beam/Postgres/BeamSchemaGen.hs
@@ -58,7 +58,7 @@ getCode connString = do
 sanitizeCode :: String -> String
 sanitizeCode str =
   addExts ++ (T.unpack moduleNameAndImports) ++ addImports ++ (T.unpack beforeMigrationTySig) ++
-    "\nmigration :: Migration PgCommandSyntax (CheckedDatabaseSettings Postgres Db)\n" ++
+    "\nmigration :: Migration Postgres (CheckedDatabaseSettings Postgres Db)\n" ++
     (T.unpack includeThisChunk) ++
     "\ndb :: DatabaseSettings Postgres Db\ndb = unCheckDatabase (runMigrationSilenced (migration))\n"
   where
@@ -88,7 +88,3 @@ addExts =
 addImports :: String
 addImports =
   "import           Database.Beam.Postgres\n\n\n"
-
-
-
-

--- a/src/Frames/SQL/Beam/Postgres/Query.hs
+++ b/src/Frames/SQL/Beam/Postgres/Query.hs
@@ -11,7 +11,7 @@ module Frames.SQL.Beam.Postgres.Query where
 import           Data.Vinyl.TypeLevel
 import           Database.Beam
 import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Syntax
+
 import           Frames.Frame
 import           Frames.InCore
 import           Frames.SQL.Beam.Postgres.Vinylize
@@ -22,7 +22,7 @@ type PostgresTable a b =
 type PostgresDB b = DatabaseSettings Postgres b
 
 type PostgresFilterLambda a s =
-  (a (QExpr PgExpressionSyntax s)) -> QExpr PgExpressionSyntax s Bool
+  (a (QExpr Postgres s)) -> QExpr Postgres s Bool
 
 type JoinQueryResults a b = [(a Identity, b Identity)]
 
@@ -34,7 +34,7 @@ type JoinQueryResults a b = [(a Identity, b Identity)]
 allRows :: (Database Postgres b, Table a) =>
             PostgresTable a b
             -> PostgresDB b
-            -> Q PgSelectSyntax b s (a (QExpr PgExpressionSyntax s))
+            -> Q Postgres b s (a (QExpr Postgres s))
 allRows tbl db = all_ (tbl db)
 
 -- | Helps select all rows from a particular table in a database that
@@ -47,7 +47,7 @@ allRowsWhere :: (Database Postgres b, Table a) =>
                 PostgresTable a b
                 -> PostgresDB b
                 -> PostgresFilterLambda a s
-                -> Q PgSelectSyntax b s (a (QExpr PgExpressionSyntax s))
+                -> Q Postgres b s (a (QExpr Postgres s))
 allRowsWhere tbl db filterLambda =
   filter_ (filterLambda) (allRows tbl db)
 
@@ -66,5 +66,3 @@ join2 joinQueryResults =
     bRecs = map createRecId bQRes
     aFrame = toFrame aRecs
     bFrame = toFrame bRecs
-
-

--- a/src/Frames/SQL/Beam/Postgres/Vinylize.hs
+++ b/src/Frames/SQL/Beam/Postgres/Vinylize.hs
@@ -10,11 +10,11 @@
 {-# LANGUAGE TypeOperators          #-}
 module Frames.SQL.Beam.Postgres.Vinylize where
 
-import           Data.Proxy
+
 import           Data.Vinyl
 import qualified Data.Vinyl.Functor               as VF
 import qualified Database.Beam                    as B
-import           Frames.Col
+
 import           Frames.SQL.Beam.Postgres.Helpers (fNamesTypeLevel)
 import           Generics.SOP
 import qualified Generics.SOP.NP                  as GSN

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-11.7
+resolver: lts-14.1
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -64,7 +64,5 @@ packages:
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
 extra-deps:
-- beam-postgres-0.3.2.0
-- beam-migrate-0.3.2.1
-- vinyl-0.10.0
-- Frames-0.5.0
+- Frames-0.6.1 # @sha256:9d628962ed6d1e835ab2b4d309d7909dc477acf6fa270879b6085621546dccaa,8595
+- discrimination-0.4 # @sha256:ad60cb42d42648ebc6f649ce761fe61cb58eca9e2b17a6b4fe68ed2e1fdd4146,2479


### PR DESCRIPTION
To build under lts-14.1, modifies the Beam function calls to conform to the updated Beam libraries; updates library versions in cabal file, and the extra-reps in stack.yaml.  Also removed redundant imports.